### PR TITLE
Fix #22

### DIFF
--- a/src/BlockHorizons/PerWorldInventory/PerWorldInventory.php
+++ b/src/BlockHorizons/PerWorldInventory/PerWorldInventory.php
@@ -33,9 +33,8 @@ class PerWorldInventory extends PluginBase {
 	private $bundled_worlds = [];
 
 	public function onEnable() : void {
-		if(!is_dir($this->getDataFolder())) {
-			mkdir($this->getDataFolder());
-			$this->saveDefaultConfig();
+		$this->saveDefaultConfig();
+		if(!is_dir($this->getDataFolder() . "inventories")) {
 			mkdir($this->getDataFolder() . "inventories");
 		}
 


### PR DESCRIPTION
This PR fixes issue #22 that was caused by the inventories folder not being created because PocketMine creates the folder of the plugin in plugin_data automatically.